### PR TITLE
Refactor DeviceTypes: Rename GOOGLE constant to ANDROID

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -17,7 +17,7 @@ if (!function_exists('decodePayload')) {
                 $tokenParts = explode(".", $payload);
                 $data = base64_decode($tokenParts[1]);
                 break;
-            case DeviceTypes::GOOGLE:
+            case DeviceTypes::ANDROID:
                 $data = base64_decode($payload);
                 break;
         }

--- a/src/Enum/DeviceTypes.php
+++ b/src/Enum/DeviceTypes.php
@@ -9,7 +9,7 @@ class DeviceTypes
 {
     private static $values = [];
     const APPLE = 'apple';
-    const GOOGLE = 'google';
+    const ANDROID = 'android';
 
     /**
      * Gets all available keys with values.

--- a/src/Helpers/Google/NotificationData.php
+++ b/src/Helpers/Google/NotificationData.php
@@ -18,7 +18,7 @@ class NotificationData extends BaseJsonClass
 
     public static function parse($data) : self
     {
-        $data                      = decodePayload($data, DeviceTypes::GOOGLE);
+        $data                      = decodePayload($data, DeviceTypes::ANDROID);
         $instance                  = new self();
         $instance->version         = $data->version;
         $instance->packageName     = $data->packageName;

--- a/src/WebhookController.php
+++ b/src/WebhookController.php
@@ -52,9 +52,9 @@ class WebhookController
             }
 
             $jobKey = GoogleNotificationTypes::JOBS[$payload->getData()->getSubscriptionNotification()->getNotificationType()];
-            $log = SubscriptionNotification::storeNotification(DeviceTypes::GOOGLE, $jobKey, $request->getContent());
+            $log = SubscriptionNotification::storeNotification(DeviceTypes::ANDROID, $jobKey, $request->getContent());
 
-            $jobClass = config("subscription-webhooks.jobs." . DeviceTypes::GOOGLE . ".{$jobKey}", null);
+            $jobClass = config("subscription-webhooks.jobs." . DeviceTypes::ANDROID . ".{$jobKey}", null);
             if (is_null($jobClass) || !class_exists($jobClass)) {
                 throw WebhookFailed::jobClassDoesNotExist($jobKey);
             }
@@ -68,7 +68,7 @@ class WebhookController
                 $log->save();
             }
             else{
-                SubscriptionNotification::storeException(DeviceTypes::GOOGLE, $jobKey ?? 'unknown', $request->getContent(), $exception->getMessage());
+                SubscriptionNotification::storeException(DeviceTypes::ANDROID, $jobKey ?? 'unknown', $request->getContent(), $exception->getMessage());
             }
             throw $exception;
         }


### PR DESCRIPTION
This commit updates the DeviceTypes class to improve clarity and consistency by renaming the GOOGLE constant to ANDROID. 
The change ensures that the naming accurately reflects the supported platform types in the application. 
All references to the constant have been updated throughout the project, ensuring consistency in naming conventions.

Changes Made:
- Renamed the GOOGLE constant to ANDROID in the DeviceTypes class
- Updated all references to the constant across the project